### PR TITLE
Work-around for unknown OpCodes emitted during headset initialization

### DIFF
--- a/mindwavemobile/MindwaveDataPoints.py
+++ b/mindwavemobile/MindwaveDataPoints.py
@@ -2,7 +2,16 @@
 class DataPoint:
     def __init__(self, dataValueBytes):
         self._dataValueBytes = dataValueBytes
-                
+
+class UnknownDataPoint(DataPoint):
+    def __init__(self, dataValueBytes):
+        DataPoint.__init__(self, dataValueBytes)
+        self.unknownPoint = self._dataValueBytes[0]
+
+    def __str__(self):
+        retMsgString = "Unknown OpCode. Value: {}".format(self.unknownPoint)
+        return retMsgString
+
 class PoorSignalLevelDataPoint(DataPoint):
     def __init__(self, dataValueBytes):
         DataPoint.__init__(self, dataValueBytes)

--- a/mindwavemobile/MindwavePacketPayloadParser.py
+++ b/mindwavemobile/MindwavePacketPayloadParser.py
@@ -1,5 +1,6 @@
 from MindwaveDataPoints import RawDataPoint, PoorSignalLevelDataPoint,\
-    AttentionDataPoint, MeditationDataPoint, BlinkDataPoint, EEGPowersDataPoint
+    AttentionDataPoint, MeditationDataPoint, BlinkDataPoint, EEGPowersDataPoint,\
+    UnknownDataPoint
 
 EXTENDED_CODE_BYTE = 0x55
 
@@ -54,6 +55,11 @@ class MindwavePacketPayloadParser:
         return dataRowValueBytes
        
     def _extractLengthOfValueBytes(self, dataRowCode):
+        # If code is one of the mysterious initial code values
+        # return before the extended code check
+        if dataRowCode == 0xBA or dataRowCode == 0xBC:
+            return 1
+
         dataRowHasLengthByte = dataRowCode > 0x7f
         if (dataRowHasLengthByte):
             return self._getNextByte()
@@ -73,6 +79,8 @@ class MindwavePacketPayloadParser:
             return RawDataPoint(dataRowValueBytes)
         elif (dataRowCode == 0x83):
             return EEGPowersDataPoint(dataRowValueBytes)
+        elif (dataRowCode == 0xba or dataRowCode == 0xbc):
+            return UnknownDataPoint(dataRowValueBytes)
         else:
             assert False 
         


### PR DESCRIPTION
* Added 'UnknownDataPoint' class as catchall for opcodes not in docs
* Added Parser 'If' clause to handle unknown op codes

The two unknown op codes only seem to be emitted during start-up, and never thereafter. This patch is a bit cheesy but works. Eventually we should figure out what they're for and do The Right Thing with them.